### PR TITLE
Can now defer update for prepended or appended text

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ The display is only updated when necessary, so there is minimal drawback for upd
   If _erase_ is true, the readout is cleared entirely.
   Otherwise, the cursor position is simply reset to the front of the bar, which will overwrite characters in the readout with subsequent output to stdout by any source
 
-* status_bar.prepend(text)
-  Displays _text_ to the left of the bar. It will always remain to the left of the bar as the display updates.  **WARNING** Prepended text offsets the bar.  If any part of the bar (including prepended or appended text) extends beyond a single line on the console, the status bar will not display properly.  Prepended text should be kept short
+* status_bar.prepend(text, updateText=True)
+  Displays _text_ to the left of the bar. It will always remain to the left of the bar as the display updates.  **WARNING** Prepended text offsets the bar.  If any part of the bar (including prepended or appended text) extends beyond a single line on the console, the status bar will not display properly.  Prepended text should be kept short. If _updateText_ is True, the display is immediately re-drawn to reflect the new text.  Otherwise, the display will wait until the next time update() is called before updating the text
 
-* status_bar.append(text)
-  Displays _text_ to the right of the bar.  It will always remain to the right of the bar as the display updates.  **WARNING** Appended text extends the display.  If any part of the bar (including prepended or appended text) extends beyond a single line of the console, the status bar will not display properly.  Appended text should be kept short
+* status_bar.append(text, updateText=True)
+  Displays _text_ to the right of the bar.  It will always remain to the right of the bar as the display updates.  **WARNING** Appended text extends the display.  If any part of the bar (including prepended or appended text) extends beyond a single line of the console, the status bar will not display properly.  Appended text should be kept short. If _updateText_ is True, the display is immediately re-drawn to reflect the new text.  Otherwise, the display will wait until the next time update() is called before updating the text
 
 ## bio.MAF2BED
 The `agutil.bio.maf2bed` module provides a command line interface for converting maf files into bed files.

--- a/agutil/src/status_bar.py
+++ b/agutil/src/status_bar.py
@@ -23,6 +23,7 @@ class status_bar:
         self.debugging = debugging
         self.update_threshold = self.maximum*update_threshold if show_percent else -1
         self.progress = 0
+        self.pending_text_update=False
         if init:
             self._initialize()
         else:
@@ -41,6 +42,7 @@ class status_bar:
             self.post_start = self.cursor+1
             self._write(self.post)
         self._backtrack_to(1+len(self.pre))
+        self.pending_text_update=False
 
 
     def _write(self, text):
@@ -76,7 +78,7 @@ class status_bar:
             self.logger.write(text)
 
     def update(self, value):
-        if not self.initialized:
+        if self.pending_text_update or not self.initialized:
             self._initialize()
         if value < 0:
             value = 0
@@ -111,14 +113,16 @@ class status_bar:
         if self.logger:
             self.logger.close()
 
-    def prepend(self, text):
+    def prepend(self, text, updateText=True):
         self.pre = text
-        if self.initialized:
+        if self.initialized and updateText:
             self._initialize()
             self.update(self.value)
+        self.pending_text_update |= not updateText
 
-    def append(self, text):
+    def append(self, text, updateText=True):
         self.post = text
-        if self.initialized:
+        if self.initialized and updateText:
             self._initialize()
             self.update(self.value)
+        self.pending_text_update |= not updateText


### PR DESCRIPTION
Theoretical use case is if some form of statistics are generated asynchronously and appended to the display.  This change avoids excessive redraws, so the statistics update when the rest of the display does