### PR TITLE
Removed pickling from securesocket's __init__

### DIFF
--- a/agutil/security/src/protocols.py
+++ b/agutil/security/src/protocols.py
@@ -35,13 +35,13 @@ def padstring(msg):
 def unpadstring(msg):
     return msg[:-1*msg[-1]]
 
-def intTobytes(num):
+def intToBytes(num):
     s = format(num, 'x')
     if len(s)%2:
         s = '0' + s
     return bytes.fromhex(s)
 
-def bytesToint(num):
+def bytesToInt(num):
     result = 0
     exp = 256 ** (len(num)-1)
     for i in range(len(num)):

--- a/agutil/security/src/protocols.py
+++ b/agutil/security/src/protocols.py
@@ -35,6 +35,18 @@ def padstring(msg):
 def unpadstring(msg):
     return msg[:-1*msg[-1]]
 
+def intTobytes(num):
+    s = format(num, 'x')
+    if len(s)%2:
+        s = '0' + s
+    return bytes.fromhex(s)
+
+def bytesToint(num):
+    result = 0
+    for i in range(len(num)):
+        result += num[0]*(256**(len(num)-i))
+    return result
+
 def _SocketWorker(_socket):
     _socket.actionlock.acquire()
     while not _socket._shutdown:

--- a/agutil/security/src/protocols.py
+++ b/agutil/security/src/protocols.py
@@ -43,8 +43,10 @@ def intTobytes(num):
 
 def bytesToint(num):
     result = 0
+    exp = 256 ** (len(num)-1)
     for i in range(len(num)):
-        result += num[0]*(256**(len(num)-i))
+        result += int(num[i]*exp)
+        exp /= 256
     return result
 
 def _SocketWorker(_socket):

--- a/agutil/security/src/securesocket.py
+++ b/agutil/security/src/securesocket.py
@@ -75,10 +75,10 @@ class SecureSocket(io.QueuedSocket):
         if self.v:
             print("Generating keypair...")
         (self.pub, self.priv) = rsa.newkeys(rsabits, True, RSA_CPU)
-        self._sendq(self._baseEncrypt(self.pub.n), '__control__')
-        self._sendq(self._baseEncrypt(self.pub.e), '__control__')
-        _n = self._baseDecrypt(self._recvq('__control__'))
-        _e = self._baseDecrypt(self._recvq('__control__'))
+        self._sendq(self._baseEncrypt(protocols.intTobytes(self.pub.n)), '__control__')
+        self._sendq(self._baseEncrypt(protocols.intTobytes(self.pub.e)), '__control__')
+        _n = protocols.bytesToint(self._baseDecrypt(self._recvq('__control__')))
+        _e = protocols.bytesToint(self._baseDecrypt(self._recvq('__control__')))
         self.rpub = rsa.PublicKey(_n, _e)
         self._sendq(rsa.encrypt(
             b'OK',

--- a/agutil/security/src/securesocket.py
+++ b/agutil/security/src/securesocket.py
@@ -4,7 +4,6 @@ import hashlib
 import rsa
 import os
 import Crypto.Cipher.AES as AES
-import pickle
 import threading
 import shutil
 from io import BytesIO
@@ -76,8 +75,11 @@ class SecureSocket(io.QueuedSocket):
         if self.v:
             print("Generating keypair...")
         (self.pub, self.priv) = rsa.newkeys(rsabits, True, RSA_CPU)
-        self._sendq(self._baseEncrypt(pickle.dumps(self.pub)), '__control__')
-        self.rpub = pickle.loads(self._baseDecrypt(self._recvq('__control__')))
+        self._sendq(self._baseEncrypt(self.pub.n), '__control__')
+        self._sendq(self._baseEncrypt(self.pub.e), '__control__')
+        _n = self._baseDecrypt(self._recvq('__control__'))
+        _e = self._baseDecrypt(self._recvq('__control__'))
+        self.rpub = rsa.PublicKey(_n, _e)
         self._sendq(rsa.encrypt(
             b'OK',
             self.rpub

--- a/agutil/security/src/securesocket.py
+++ b/agutil/security/src/securesocket.py
@@ -75,10 +75,10 @@ class SecureSocket(io.QueuedSocket):
         if self.v:
             print("Generating keypair...")
         (self.pub, self.priv) = rsa.newkeys(rsabits, True, RSA_CPU)
-        self._sendq(self._baseEncrypt(protocols.intTobytes(self.pub.n)), '__control__')
-        self._sendq(self._baseEncrypt(protocols.intTobytes(self.pub.e)), '__control__')
-        _n = protocols.bytesToint(self._baseDecrypt(self._recvq('__control__')))
-        _e = protocols.bytesToint(self._baseDecrypt(self._recvq('__control__')))
+        self._sendq(self._baseEncrypt(protocols.intToBytes(self.pub.n)), '__control__')
+        self._sendq(self._baseEncrypt(protocols.intToBytes(self.pub.e)), '__control__')
+        _n = protocols.bytesToInt(self._baseDecrypt(self._recvq('__control__')))
+        _e = protocols.bytesToInt(self._baseDecrypt(self._recvq('__control__')))
         self.rpub = rsa.PublicKey(_n, _e)
         self._sendq(rsa.encrypt(
             b'OK',


### PR DESCRIPTION
Pubkeys are now exchanged by sending n and e

See #62 