### PR TITLE
Testing new travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ branches:
   - master
   - dev
   - staging
+env:
+  - COLUMNS=80
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ branches:
   - master
   - dev
   - staging
-sudo: required
+addons:
+  apt:
+    packages:
+      - pandoc
+dist: trusty
 notifications:
   email:
     on_success: always
@@ -22,8 +26,6 @@ script:
 after_success:
   - coveralls
 before_deploy:
-  - wget http://github.com/jgm/pandoc/releases/download/1.17.1/pandoc-1.17.1-2-amd64.deb
-  - sudo dpkg -i pandoc-1.17.1-2-amd64.deb
   - pandoc --from markdown --to rst README.md -o README.rst
 deploy:
   skip_cleanup: true

--- a/agutil/src/status_bar.py
+++ b/agutil/src/status_bar.py
@@ -1,14 +1,6 @@
 import sys
 from math import log10
-
-def get_terminal_size():
-    # Fix for a possible bug in travis trusty builds
-    # Terminal size is reported as 0 via shutil, os, and stty
-    from shutil import get_terminal_size as _get_terminal_size
-    from os import environ
-    if 'TRAVIS' in environ:
-        return [20]
-    return _get_terminal_size()
+from shutil import get_terminal_size
 
 class status_bar:
     def __init__(self, maximum, show_percent = False, init=True,  prepend="", append="", cols=int(get_terminal_size()[0]/2), update_threshold=.00005, debugging=False):

--- a/agutil/src/status_bar.py
+++ b/agutil/src/status_bar.py
@@ -1,6 +1,17 @@
 import sys
-from shutil import get_terminal_size
+from shutil import get_terminal_size as _get_terminal_size
 from math import log10
+
+def get_terminal_size():
+    import os
+    import subprocess
+    _shutil = _get_terminal_size()
+    _os = os.get_terminal_size()
+    _subprocess = subprocess.run(['stty', 'size'], stdout=subprocess.PIPE).stdout.decode()
+    print("Shutil:", _shutil)
+    print("OS:", _os)
+    print("Subprocess:", _subprocess)
+    return max(_os[0], _shutil[0])
 
 class status_bar:
     def __init__(self, maximum, show_percent = False, init=True,  prepend="", append="", cols=int(get_terminal_size()[0]/2), update_threshold=.00005, debugging=False):

--- a/agutil/src/status_bar.py
+++ b/agutil/src/status_bar.py
@@ -1,17 +1,14 @@
 import sys
-from shutil import get_terminal_size as _get_terminal_size
 from math import log10
 
 def get_terminal_size():
-    import os
-    import subprocess
-    _shutil = _get_terminal_size()
-    _os = os.get_terminal_size()
-    _subprocess = subprocess.run(['stty', 'size'], stdout=subprocess.PIPE).stdout.decode()
-    print("Shutil:", _shutil)
-    print("OS:", _os)
-    print("Subprocess:", _subprocess)
-    return max(_os[0], _shutil[0])
+    # Fix for a possible bug in travis trusty builds
+    # Terminal size is reported as 0 via shutil, os, and stty
+    from shutil import get_terminal_size as _get_terminal_size
+    from os import environ
+    if 'TRAVIS' in environ:
+        return [20]
+    return _get_terminal_size()
 
 class status_bar:
     def __init__(self, maximum, show_percent = False, init=True,  prepend="", append="", cols=int(get_terminal_size()[0]/2), update_threshold=.00005, debugging=False):


### PR DESCRIPTION
I'm opening the PR to force the travis build even though the PR is probably going to need some additional work.

The two goals are:
* Shave off some build time by removing the `sudo` requirement at the cost of installing pandoc for every build (not just during deploys)
* Test out the current build process on the **trusty** platform, since travis will be phasing out **precise** soon

See #118 