### PR TITLE
Added cmd() function

### DIFF
--- a/agutil/__init__.py
+++ b/agutil/__init__.py
@@ -2,3 +2,4 @@ from .src.search_range import search_range
 from .src.status_bar import status_bar
 from .src.logger import Logger, DummyLog
 from .src.misc import split_iterable, byte_xor, intToBytes, bytesToInt, hashfile, byteSize
+from .src.shell import cmd, StdOutAdapter, ShellReturnObject

--- a/agutil/src/shell.py
+++ b/agutil/src/shell.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import subprocess
+import threading
+from shlex import quote
+
+class ShellReturnObject:
+    def __init__(self, command, stdoutAdapter, returncode):
+        self.returncode = int(returncode)
+        self.buffer = b''
+        self.rawbuffer = stdoutAdapter.readBuffer()
+        for char in self.rawbuffer:
+            if char == 8:#backspace
+                self.buffer = self.buffer[:-1]
+            else:
+                self.buffer += bytes.fromhex('%02x'%char)
+        self.command = ""+command
+
+    def __repr__(self):
+        return "<ShellReturnObject returncode=%d command=\"%s\">"%(
+            self.returncode,
+            self.command
+        )
+
+class StdOutAdapter:
+    def __init__(self, display:bool):
+        (self.readFD, self.writeFD) = os.pipe()
+        os.set_inheritable(self.writeFD, True)
+        self.buffer = b''
+        self.display = bool(display)
+        self._thread = threading.Thread(
+            target = StdOutAdapter._threadWorker,
+            args=(self,),
+            daemon=True
+        )
+        self._thread.start()
+
+    def kill(self):
+        try:
+            os.close(self.writeFD)
+        except OSError:
+            pass
+        self._thread.join()
+        try:
+            os.close(self.readFD)
+        except OSError:
+            pass
+
+    def readBuffer(self):
+        if self._thread.is_alive():
+            return b''
+        return self.buffer
+
+    def _threadWorker(self):
+        intake = os.read(self.readFD, 64)
+        while len(intake):
+            if(self.display):
+                os.write(sys.stdout.fileno(), intake)
+            self.buffer += intake
+            intake = os.read(self.readFD, 64)
+
+
+def cmd(expr, display=True):
+    if type(expr) in {list, tuple}:
+        expr = " ".join([quote(token) for token in expr])
+    adapter = StdOutAdapter(display)
+    stdinFD = os.dup(sys.stdin.fileno())
+    proc = subprocess.run(
+        expr,
+        shell=True,
+        stdout = adapter.writeFD,
+        stderr = adapter.writeFD,
+        stdin = stdinFD,
+        universal_newlines = False
+    )
+    adapter.kill()
+    os.close(stdinFD)
+    return ShellReturnObject(expr, adapter, proc.returncode)

--- a/agutil/src/shell.py
+++ b/agutil/src/shell.py
@@ -25,7 +25,6 @@ class ShellReturnObject:
 class StdOutAdapter:
     def __init__(self, display:bool):
         (self.readFD, self.writeFD) = os.pipe()
-        os.set_inheritable(self.writeFD, True)
         self.buffer = b''
         self.display = bool(display)
         self._thread = threading.Thread(
@@ -65,7 +64,7 @@ def cmd(expr, display=True):
         expr = " ".join([quote(token) for token in expr])
     adapter = StdOutAdapter(display)
     stdinFD = os.dup(sys.stdin.fileno())
-    proc = subprocess.run(
+    proc = subprocess.Popen(
         expr,
         shell=True,
         stdout = adapter.writeFD,
@@ -73,6 +72,7 @@ def cmd(expr, display=True):
         stdin = stdinFD,
         universal_newlines = False
     )
+    proc.wait()
     adapter.kill()
     os.close(stdinFD)
     return ShellReturnObject(expr, adapter, proc.returncode)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -31,15 +31,12 @@ class test(unittest.TestCase):
             'ls',
             'pwd',
             'echo hi',
-            'ps -o pid,command'
+            'ps -o command'
         ]
         for command in commands:
-            expected = subprocess.run(
+            expected = subprocess.check_output(
                 command,
                 shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT
             )
             observed = cmd(command, display=False)
-            self.assertEqual(expected.returncode, observed.returncode)
-            self.assertEqual(expected.stdout, observed.rawbuffer)
+            self.assertEqual(expected, observed.rawbuffer)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -31,12 +31,19 @@ class test(unittest.TestCase):
             'ls',
             'pwd',
             'echo hi',
-            'ps -o command'
+            'ps -o command',
+            'df',
+            'which python',
+            'whoami'
         ]
         for command in commands:
-            expected = subprocess.check_output(
+            expected = subprocess.Popen(
                 command,
                 shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT
             )
+            expected.wait()
             observed = cmd(command, display=False)
-            self.assertEqual(expected, observed.rawbuffer)
+            self.assertEqual(expected.stdout.read(), observed.rawbuffer)
+            expected.stdout.close()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,45 @@
+import unittest
+import os
+from py_compile import compile
+import sys
+import random
+import subprocess
+
+class test(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.script_path = os.path.join(
+            os.path.dirname(
+                os.path.dirname(
+                    os.path.abspath(__file__)
+                )
+            ),
+            "agutil",
+            "src",
+            "shell.py"
+        )
+        sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(cls.script_path))))
+        random.seed()
+
+    def test_compilation(self):
+        compiled_path = compile(self.script_path)
+        self.assertTrue(compiled_path)
+
+    def test_shell_commands(self):
+        from agutil import cmd
+        commands = [
+            'ls',
+            'pwd',
+            'echo hi',
+            'ps -o pid,command'
+        ]
+        for command in commands:
+            expected = subprocess.run(
+                command,
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT
+            )
+            observed = cmd(command, display=False)
+            self.assertEqual(expected.returncode, observed.returncode)
+            self.assertEqual(expected.stdout, observed.rawbuffer)


### PR DESCRIPTION
ShellReturnObject and StdoutAdapter are support classes for the cmd() function which is a shorthand for making calls to the system shell within python.  The general idea is that cmd() makes python more viable as a primary shell by adding a very simple shorthand for the subprocess module.  Specifically, this helps a separate project I'm working on called `pysh`, a shell which takes mixed python and shell syntax.