### PR TITLE
Socket-related tests now use port_for to select open ports

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,2 +1,8 @@
 branch: dev
+
 label_prs: dependencies
+
+requirements:
+  - tests/requirements.txt:
+    updates: all
+    pin: True

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ python:
   - '3.6'
 install:
   - pip install -e .
+  - pip install -r tests/requirements.txt
   - pip install coveralls
 script:
   - coverage run --source=agutil --omit=*__init__.py -m unittest discover -v

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,13 @@ setup(
             session=''
         )
     ],
+    tests_require=[
+        str(package.req) for package in parse_requirements(
+            'tests/requirements.txt',
+            session=''
+        )
+    ],
+    test_suite='tests',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,1 @@
+port-for

--- a/tests/test_queuedsocket.py
+++ b/tests/test_queuedsocket.py
@@ -6,6 +6,7 @@ import random
 import threading
 import warnings
 import os
+import port_for as pf
 startup_lock = threading.Lock()
 
 TRAVIS = 'CI' in os.environ
@@ -95,16 +96,16 @@ class test(unittest.TestCase):
         from agutil.io import Socket
         ss = None
         warnings.simplefilter('ignore', ResourceWarning)
-        for port in range(4000, 5000):
+        for attempt in range(10):
             try:
-                ss = SocketServer(port)
+                ss = SocketServer(pf.select_random())
             except OSError:
                 if ss!=None:
                     ss.close()
             if ss!=None:
                 break
         warnings.resetwarnings()
-        self.assertIsInstance(ss, SocketServer, "Failed to bind to any ports on [4000, 5000]")
+        self.assertIsInstance(ss, SocketServer, "Failed to bind to any ports after 10 attempts")
         startup_lock.acquire()
         server_payload = lambda x:None
         client_payload = lambda x:None

--- a/tests/test_securesocket.py
+++ b/tests/test_securesocket.py
@@ -6,6 +6,7 @@ import random
 import threading
 import warnings
 import os
+import port_for as pf
 startup_lock = threading.Lock()
 
 TRAVIS = 'CI' in os.environ
@@ -98,16 +99,16 @@ class test(unittest.TestCase):
         from agutil.security import SecureSocket
         ss = None
         warnings.simplefilter('ignore', ResourceWarning)
-        for port in range(5000, 6000):
+        for attempt in range(10):
             try:
-                ss = SocketServer(port)
+                ss = SocketServer(pf.select_random())
             except OSError:
                 if ss!=None:
                     ss.close()
             if ss!=None:
                 break
         warnings.resetwarnings()
-        self.assertIsInstance(ss, SocketServer, "Failed to bind to any ports on [5000, 6000]")
+        self.assertIsInstance(ss, SocketServer, "Failed to bind to any ports after 10 attempts")
         startup_lock.acquire()
         server_payload = lambda x:None
         client_payload = lambda x:None

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -9,6 +9,7 @@ import tempfile
 import os
 import time
 import io
+import port_for as pf
 
 TRAVIS = 'CI' in os.environ
 
@@ -173,15 +174,15 @@ class test(unittest.TestCase):
         warnings.simplefilter('ignore', ResourceWarning)
         server_thread = None
         found_port = -1
-        for port in range(6000, 7000):
-            server_thread = threading.Thread(target=server_comms, args=(SecureServer, port, server_payload), name='Server thread', daemon=True)
+        for attempt in range(10):
+            found_port = pf.select_random()
+            server_thread = threading.Thread(target=server_comms, args=(SecureServer, found_port, server_payload), name='Server thread', daemon=True)
             server_thread.start()
             server_thread.join(1)
             if server_thread.is_alive():
-                found_port = port
                 break
         warnings.resetwarnings()
-        self.assertGreater(found_port, 5999, "Failed to bind to any ports on [6000, 7000]")
+        self.assertTrue(server_thread.is_alive(), "Failed to bind to any ports after 10 attempts")
         client_payload = lambda x:None
         client_thread = threading.Thread(target=client_comms, args=(SecureConnection, found_port, client_payload), daemon=True)
         client_thread.start()
@@ -211,15 +212,15 @@ class test(unittest.TestCase):
         warnings.simplefilter('ignore', ResourceWarning)
         server_thread = None
         found_port = -1
-        for port in range(7000, 8000):
-            server_thread = threading.Thread(target=server_comms_files, args=(SecureServer, port, server_payload), name='Server thread', daemon=True)
+        for attempt in range(10):
+            found_port = pf.select_random()
+            server_thread = threading.Thread(target=server_comms_files, args=(SecureServer, found_port, server_payload), name='Server thread', daemon=True)
             server_thread.start()
             server_thread.join(1)
             if server_thread.is_alive():
-                found_port = port
                 break
         warnings.resetwarnings()
-        self.assertGreater(found_port, 6999, "Failed to bind to any ports on [7000, 8000]")
+        self.assertTrue(server_thread.is_alive(), "Failed to bind to any ports after 10 attempts")
         client_payload = lambda x:None
         client_thread = threading.Thread(target=client_comms_files, args=(SecureConnection, found_port, client_payload), daemon=True)
         client_thread.start()

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -6,6 +6,7 @@ import random
 import threading
 import warnings
 import os
+import port_for as pf
 startup_lock = threading.Lock()
 
 TRAVIS = 'CI' in os.environ
@@ -75,16 +76,16 @@ class test(unittest.TestCase):
         from agutil.io import Socket
         ss = None
         warnings.simplefilter('ignore', ResourceWarning)
-        for port in range(8000, 9000):
+        for attempt in range(10):
             try:
-                ss = SocketServer(port)
+                ss = SocketServer(pf.select_random())
             except OSError:
                 if ss!=None:
                     ss.close()
             if ss!=None:
                 break
         warnings.resetwarnings()
-        self.assertIsInstance(ss, SocketServer, "Failed to bind to any ports on [8000, 9000]")
+        self.assertIsInstance(ss, SocketServer, "Failed to bind to any ports after 10 attempts")
         startup_lock.acquire()
         server_payload = lambda x:None
         client_payload = lambda x:None


### PR DESCRIPTION
Also reworked pyup config slightly to include port_for as a test-only dependency

See #133 